### PR TITLE
Substract cache from memory usage.

### DIFF
--- a/docker_memory
+++ b/docker_memory
@@ -70,6 +70,16 @@ for my $i (1 .. $#containers)
    {
       my $memory_bytes = <$file>;
       $memory_bytes =~ s/\s+$//;
+      if (open(my $file, '<', "/sys/fs/cgroup/memory/docker/$id/memory.stat"))
+      {
+         my %stat;
+         while (my $line = <$file>)
+         {
+            $line =~ m/^(\w+) (\d+)$/;
+            $stat{$1} = $2;
+         }
+         $memory_bytes -= $stat{"cache"};
+      }
       push @result, {'name'=>$name, 'memory_bytes'=>$memory_bytes};
    }
 }


### PR DESCRIPTION
Including it seemed a bit misleading to me, as it doesn't reflect actual memory usage and wouldn't trigger eg. OOM. It also makes it hard to compare different container's behavior, where one might be leaking memory and the other just caching a lot.

Ref moby/moby#10824